### PR TITLE
feat : Robot API 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.54</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/src/main/java/com/cnu/simple/robot/Robot.java
+++ b/src/main/java/com/cnu/simple/robot/Robot.java
@@ -1,15 +1,10 @@
 package com.cnu.simple.robot;
 
 import com.cnu.simple.work.WorkSpecification;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
 import java.util.List;
-import java.util.UUID;
 
 @Getter
 @Entity
@@ -22,35 +17,29 @@ public class Robot {
     private Long id;
 
     @Column(name = "name")
-    @Setter
     private String name;
 
     @Column(name = "SSH_Id")
-    @Setter
     private String sshId;
 
     @Column(name = "SSH_PW")
-    @Setter
     private String sshPw;
 
     @Column(name = "port")
-    @Setter
     private int port;
 
-    @OneToMany
-    @JoinColumn(name = "work_spec_id", referencedColumnName = "id")
+    @OneToMany(mappedBy = "robot")
     private List<WorkSpecification> workSpecifications;
 
     @Column(name = "IP")
-    @Setter
     private String ip;
 
     @Column(name = "type")
-    @Setter
     private String type;
 
     @Builder
-    public Robot(String name, String sshId, String sshPw, int port, String ip, String type) {
+    public Robot(Long id,String name, String sshId, String sshPw, int port, String ip, String type) {
+        this.id = id;
         this.name = name;
         this.sshId = sshId;
         this.sshPw = sshPw;

--- a/src/main/java/com/cnu/simple/robot/Robot.java
+++ b/src/main/java/com/cnu/simple/robot/Robot.java
@@ -1,39 +1,61 @@
 package com.cnu.simple.robot;
 
 import com.cnu.simple.work.WorkSpecification;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 
+import java.util.List;
 import java.util.UUID;
 
+@Getter
 @Entity
 @Table(name = "robots")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Robot {
     @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", nullable = false, unique = true, columnDefinition = "BINARY(16)")
-    private UUID id;
+    private Long id;
 
     @Column(name = "name")
+    @Setter
     private String name;
 
     @Column(name = "SSH_Id")
+    @Setter
     private String sshId;
 
     @Column(name = "SSH_PW")
+    @Setter
     private String sshPw;
 
     @Column(name = "port")
+    @Setter
     private int port;
 
-    @ManyToOne
+    @OneToMany
     @JoinColumn(name = "work_spec_id", referencedColumnName = "id")
-    private WorkSpecification workSpecification;
+    private List<WorkSpecification> workSpecifications;
 
     @Column(name = "IP")
+    @Setter
     private String ip;
 
-    @Column(name = "memo")
-    private String memo;
+    @Column(name = "type")
+    @Setter
+    private String type;
+
+    @Builder
+    public Robot(String name, String sshId, String sshPw, int port, String ip, String type) {
+        this.name = name;
+        this.sshId = sshId;
+        this.sshPw = sshPw;
+        this.port = port;
+        this.ip = ip;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/cnu/simple/robot/RobotController.java
+++ b/src/main/java/com/cnu/simple/robot/RobotController.java
@@ -1,0 +1,65 @@
+package com.cnu.simple.robot;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/robot")
+@RequiredArgsConstructor
+public class RobotController {
+    private final RobotService robotService;
+
+    @PostMapping
+    public ResponseEntity<Robot> createRobot(@RequestBody RobotRequest robotRequest) {
+        Robot createdRobot = robotService.createPost(robotRequest);
+        return new ResponseEntity<>(createdRobot, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Robot>> getRobots() {
+        List<Robot> robots = robotService.getPosts();
+        return ResponseEntity.ok(robots);
+    }
+
+    @GetMapping("/{robotId}")
+    public ResponseEntity<Robot> getRobot(@PathVariable("robotId") Integer robotId) {
+        Optional<Robot> robot = robotService.getPost(robotId);
+        if (robot.isPresent()) {
+            return ResponseEntity.ok(robot.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PutMapping("/{robotId}")
+    public ResponseEntity<Robot> updateRobot(@PathVariable("robotId")Integer robotId,
+                                             @RequestBody RobotRequest robotRequest) {
+        Optional<Robot> updatedRobot = robotService.updatePost(robotId, robotRequest);
+        if (updatedRobot.isPresent()) {
+            return ResponseEntity.ok(updatedRobot.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{robotId}")
+    public ResponseEntity<Void> deleteRobot(@PathVariable("robotId") Integer robotId) {
+        robotService.deletePost(robotId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/test/connection")
+    public ResponseEntity<Boolean> connectRobot(@RequestBody RobotRequest robotRequest) {
+        boolean isSuccess = robotService.testSshConnection(robotRequest);
+        if (isSuccess) {
+            return ResponseEntity.ok(true);
+        } else {
+            return ResponseEntity.badRequest().body(false);
+        }
+    }
+}

--- a/src/main/java/com/cnu/simple/robot/RobotController.java
+++ b/src/main/java/com/cnu/simple/robot/RobotController.java
@@ -16,19 +16,19 @@ public class RobotController {
 
     @PostMapping
     public ResponseEntity<Robot> createRobot(@RequestBody RobotRequest robotRequest) {
-        Robot createdRobot = robotService.createPost(robotRequest);
+        Robot createdRobot = robotService.createRobot(robotRequest);
         return new ResponseEntity<>(createdRobot, HttpStatus.CREATED);
     }
 
     @GetMapping
     public ResponseEntity<List<Robot>> getRobots() {
-        List<Robot> robots = robotService.getPosts();
+        List<Robot> robots = robotService.getRobots();
         return ResponseEntity.ok(robots);
     }
 
     @GetMapping("/{robotId}")
     public ResponseEntity<Robot> getRobot(@PathVariable("robotId") Integer robotId) {
-        Optional<Robot> robot = robotService.getPost(robotId);
+        Optional<Robot> robot = robotService.getRobot(robotId);
         if (robot.isPresent()) {
             return ResponseEntity.ok(robot.get());
         } else {
@@ -39,7 +39,7 @@ public class RobotController {
     @PutMapping("/{robotId}")
     public ResponseEntity<Robot> updateRobot(@PathVariable("robotId")Integer robotId,
                                              @RequestBody RobotRequest robotRequest) {
-        Optional<Robot> updatedRobot = robotService.updatePost(robotId, robotRequest);
+        Optional<Robot> updatedRobot = robotService.updateRobot(robotId, robotRequest);
         if (updatedRobot.isPresent()) {
             return ResponseEntity.ok(updatedRobot.get());
         } else {
@@ -49,7 +49,7 @@ public class RobotController {
 
     @DeleteMapping("/{robotId}")
     public ResponseEntity<Void> deleteRobot(@PathVariable("robotId") Integer robotId) {
-        robotService.deletePost(robotId);
+        robotService.deleteRobot(robotId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/cnu/simple/robot/RobotController.java
+++ b/src/main/java/com/cnu/simple/robot/RobotController.java
@@ -15,33 +15,33 @@ public class RobotController {
     private final RobotService robotService;
 
     @PostMapping
-    public ResponseEntity<Robot> createRobot(@RequestBody RobotRequest robotRequest) {
-        Robot createdRobot = robotService.createRobot(robotRequest);
+    public ResponseEntity<RobotDto> createRobot(@RequestBody RobotDto robotDto) {
+        RobotDto createdRobot = robotService.createRobot(robotDto);
         return new ResponseEntity<>(createdRobot, HttpStatus.CREATED);
     }
 
     @GetMapping
-    public ResponseEntity<List<Robot>> getRobots() {
-        List<Robot> robots = robotService.getRobots();
-        return ResponseEntity.ok(robots);
+    public ResponseEntity<List<RobotDto>> getRobots() {
+        List<RobotDto> robotDtos = robotService.getRobots();
+        return ResponseEntity.ok(robotDtos);
     }
 
     @GetMapping("/{robotId}")
-    public ResponseEntity<Robot> getRobot(@PathVariable("robotId") Integer robotId) {
-        Optional<Robot> robot = robotService.getRobot(robotId);
-        if (robot.isPresent()) {
-            return ResponseEntity.ok(robot.get());
+    public ResponseEntity<RobotDto> getRobot(@PathVariable("robotId") Integer robotId) {
+        Optional<RobotDto> RobotRequest = robotService.getRobot(robotId);
+        if (RobotRequest.isPresent()) {
+            return ResponseEntity.ok(RobotRequest.get());
         } else {
             return ResponseEntity.notFound().build();
         }
     }
 
     @PutMapping("/{robotId}")
-    public ResponseEntity<Robot> updateRobot(@PathVariable("robotId")Integer robotId,
-                                             @RequestBody RobotRequest robotRequest) {
-        Optional<Robot> updatedRobot = robotService.updateRobot(robotId, robotRequest);
-        if (updatedRobot.isPresent()) {
-            return ResponseEntity.ok(updatedRobot.get());
+    public ResponseEntity<RobotDto> updateRobot(@PathVariable("robotId")Integer robotId,
+                                                @RequestBody RobotDto robotDto) {
+        Optional<RobotDto> updatedRobotRequest = robotService.updateRobot(robotId, robotDto);
+        if (updatedRobotRequest.isPresent()) {
+            return ResponseEntity.ok(updatedRobotRequest.get());
         } else {
             return ResponseEntity.notFound().build();
         }
@@ -54,8 +54,8 @@ public class RobotController {
     }
 
     @PostMapping("/test/connection")
-    public ResponseEntity<Boolean> connectRobot(@RequestBody RobotRequest robotRequest) {
-        boolean isSuccess = robotService.testSshConnection(robotRequest);
+    public ResponseEntity<Boolean> connectRobot(@RequestBody RobotDto robotDto) {
+        boolean isSuccess = robotService.testSshConnection(robotDto);
         if (isSuccess) {
             return ResponseEntity.ok(true);
         } else {

--- a/src/main/java/com/cnu/simple/robot/RobotDto.java
+++ b/src/main/java/com/cnu/simple/robot/RobotDto.java
@@ -1,33 +1,21 @@
 package com.cnu.simple.robot;
 
-import com.cnu.simple.work.WorkSpecification;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
-import jakarta.persistence.Column;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
+import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-import java.util.UUID;
-
 @Getter
-public class RobotRequest {
+public class RobotDto {
+    private Long id;
     private String name;
-
     private String sshId;
-
     private String sshPw;
-
     private int port;
-
-    private List<WorkSpecification> workSpecifications;
     private String ip;
     private String type;
 
     public Robot toEntity() {
         return Robot.builder()
+                .id(id)
                 .name(name)
                 .sshId(sshId)
                 .sshPw(sshPw)
@@ -35,5 +23,15 @@ public class RobotRequest {
                 .ip(ip)
                 .type(type)
                 .build();
+    }
+
+    public RobotDto(Robot robot) {
+        this.id = robot.getId();
+        this.name = robot.getName();
+        this.sshId = robot.getSshId();
+        this.sshPw = robot.getSshPw();
+        this.port = robot.getPort();
+        this.ip = robot.getIp();
+        this.type = robot.getType();
     }
 }

--- a/src/main/java/com/cnu/simple/robot/RobotRepository.java
+++ b/src/main/java/com/cnu/simple/robot/RobotRepository.java
@@ -1,0 +1,8 @@
+package com.cnu.simple.robot;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RobotRepository extends JpaRepository<Robot, Integer> {
+}

--- a/src/main/java/com/cnu/simple/robot/RobotRequest.java
+++ b/src/main/java/com/cnu/simple/robot/RobotRequest.java
@@ -1,0 +1,39 @@
+package com.cnu.simple.robot;
+
+import com.cnu.simple.work.WorkSpecification;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import jakarta.persistence.Column;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class RobotRequest {
+    private String name;
+
+    private String sshId;
+
+    private String sshPw;
+
+    private int port;
+
+    private List<WorkSpecification> workSpecifications;
+    private String ip;
+    private String type;
+
+    public Robot toEntity() {
+        return Robot.builder()
+                .name(name)
+                .sshId(sshId)
+                .sshPw(sshPw)
+                .port(port)
+                .ip(ip)
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/cnu/simple/robot/RobotService.java
+++ b/src/main/java/com/cnu/simple/robot/RobotService.java
@@ -1,0 +1,65 @@
+package com.cnu.simple.robot;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RobotService {
+    private final RobotRepository robotRepository;
+
+    public Robot createPost(RobotRequest robotRequest) {
+        return robotRepository.save(robotRequest.toEntity());
+    }
+
+    public List<Robot> getPosts() {
+        return robotRepository.findAll();
+    }
+
+    public Optional<Robot> getPost(Integer postId) {
+        return robotRepository.findById(postId);
+    }
+
+    public Optional<Robot> updatePost(Integer robotId, RobotRequest robotRequest) {
+        return robotRepository.findById(robotId)
+                .map(robot -> {
+                    robot.setName(robotRequest.getName());
+                    robot.setSshId(robotRequest.getSshId());
+                    robot.setSshPw(robotRequest.getSshPw());
+                    robot.setPort(robotRequest.getPort());
+                    robot.setIp(robotRequest.getIp());
+                    robot.setType(robotRequest.getType());
+
+                    return robotRepository.save(robot);
+                });
+    }
+
+    public void deletePost(Integer postId) {
+        robotRepository.findById(postId)
+                .ifPresent(robotRepository::delete);
+    }
+
+    public boolean testSshConnection(RobotRequest robotRequest) {
+        JSch jsch = new JSch();
+        Session session = null;
+        try {
+            session = jsch.getSession(robotRequest.getSshId(), robotRequest.getIp(), robotRequest.getPort());
+            session.setPassword(robotRequest.getSshPw());
+            session.setConfig("StrictHostKeyChecking", "no");
+            session.connect();
+            return true;
+        } catch (JSchException e) {
+            return false;
+        } finally {
+            if (session != null) {
+                session.disconnect();
+            }
+        }
+    }
+}

--- a/src/main/java/com/cnu/simple/robot/RobotService.java
+++ b/src/main/java/com/cnu/simple/robot/RobotService.java
@@ -8,49 +8,49 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RobotService {
     private final RobotRepository robotRepository;
 
-    public Robot createRobot(RobotRequest robotRequest) {
-        return robotRepository.save(robotRequest.toEntity());
+    public RobotDto createRobot(RobotDto robotDto) {
+        robotRepository.save(robotDto.toEntity());
+        return robotDto;
     }
 
-    public List<Robot> getRobots() {
-        return robotRepository.findAll();
+    public List<RobotDto> getRobots() {
+        List<Robot> robots = robotRepository.findAll();
+        return robots.stream()
+                .map(RobotDto::new)
+                .collect(Collectors.toList());
     }
 
-    public Optional<Robot> getRobot(Integer RobotId) {
-        return robotRepository.findById(RobotId);
+    public Optional<RobotDto> getRobot(Integer robotId) {
+        return robotRepository.findById(robotId)
+                .map(RobotDto::new);
     }
 
-    public Optional<Robot> updateRobot(Integer robotId, RobotRequest robotRequest) {
+    public Optional<RobotDto> updateRobot(Integer robotId, RobotDto robotDto) {
         return robotRepository.findById(robotId)
                 .map(robot -> {
-                    robot.setName(robotRequest.getName());
-                    robot.setSshId(robotRequest.getSshId());
-                    robot.setSshPw(robotRequest.getSshPw());
-                    robot.setPort(robotRequest.getPort());
-                    robot.setIp(robotRequest.getIp());
-                    robot.setType(robotRequest.getType());
-
-                    return robotRepository.save(robot);
+                    Robot updatedRobot = robotRepository.save(robot);
+                    return new RobotDto(updatedRobot);
                 });
     }
 
-    public void deleteRobot(Integer RobotId) {
-        robotRepository.findById(RobotId)
+    public void deleteRobot(Integer robotId) {
+        robotRepository.findById(robotId)
                 .ifPresent(robotRepository::delete);
     }
 
-    public boolean testSshConnection(RobotRequest robotRequest) {
+    public boolean testSshConnection(RobotDto robotDto) {
         JSch jsch = new JSch();
         Session session = null;
         try {
-            session = jsch.getSession(robotRequest.getSshId(), robotRequest.getIp(), robotRequest.getPort());
-            session.setPassword(robotRequest.getSshPw());
+            session = jsch.getSession(robotDto.getSshId(), robotDto.getIp(), robotDto.getPort());
+            session.setPassword(robotDto.getSshPw());
             session.setConfig("StrictHostKeyChecking", "no");
             session.connect();
             return true;

--- a/src/main/java/com/cnu/simple/robot/RobotService.java
+++ b/src/main/java/com/cnu/simple/robot/RobotService.java
@@ -14,19 +14,19 @@ import java.util.Optional;
 public class RobotService {
     private final RobotRepository robotRepository;
 
-    public Robot createPost(RobotRequest robotRequest) {
+    public Robot createRobot(RobotRequest robotRequest) {
         return robotRepository.save(robotRequest.toEntity());
     }
 
-    public List<Robot> getPosts() {
+    public List<Robot> getRobots() {
         return robotRepository.findAll();
     }
 
-    public Optional<Robot> getPost(Integer postId) {
-        return robotRepository.findById(postId);
+    public Optional<Robot> getRobot(Integer RobotId) {
+        return robotRepository.findById(RobotId);
     }
 
-    public Optional<Robot> updatePost(Integer robotId, RobotRequest robotRequest) {
+    public Optional<Robot> updateRobot(Integer robotId, RobotRequest robotRequest) {
         return robotRepository.findById(robotId)
                 .map(robot -> {
                     robot.setName(robotRequest.getName());
@@ -40,8 +40,8 @@ public class RobotService {
                 });
     }
 
-    public void deletePost(Integer postId) {
-        robotRepository.findById(postId)
+    public void deleteRobot(Integer RobotId) {
+        robotRepository.findById(RobotId)
                 .ifPresent(robotRepository::delete);
     }
 


### PR DESCRIPTION
구현
1. Robot의 CRUD API 구현
2. Robot testSshConnection 기능을 RobotService 내부에 구현

Robot : API 명세에 맞춰 type 추가
RobotController, RobotRepository, RobotService : CRUD
RobotRequest : request 요청을 받고 Robot Entity를 생성

중점적으로 봐줬으면 하는 부분
1. RobotService의 testSshConnection 기능
2. Robot entity의 work_spec_id의 관계 매핑